### PR TITLE
Allow redirects in curl

### DIFF
--- a/lua/py-requirements/api.lua
+++ b/lua/py-requirements/api.lua
@@ -2,7 +2,7 @@ local curl = require('plenary.curl')
 
 ---@return string[]
 local function parse_versions(result)
-    if result == nil or result.status ~= 200 then
+    if result == nil or (result.status ~= 200 and result.status ~= 301) then
         return {}
     end
     local json = vim.json.decode(result.body)
@@ -38,6 +38,7 @@ function M.get_versions(name)
             ['Accept'] = 'application/vnd.pypi.simple.v1+json',
             ['User-Agent'] = 'py-requirements.nvim (https://github.com/MeanderingProgrammer/py-requirements.nvim)',
         },
+        raw = { '--location' },
     })
     local versions = parse_versions(result)
     cache.versions[name] = versions


### PR DESCRIPTION
Some PIP packages have canonical names that redirect to a secondary URL when polling pypi (e.g. https://pypi.org/simple/discord.py/ redirecting to https://pypi.org/simple/discord-py/) - this would allow curl to follow these redirections.