### PR TITLE
Allow configuring multiple requirement file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ https://github.com/MeanderingProgrammer/py-requirements.nvim/assets/52591095/6ff
         require('py-requirements').setup({
             -- Enabled by default if you do not use `nvim-cmp` set to false
             enable_cmp = true,
+            -- Specify what file patterns to apply the plugin to, for use with for example pip-tools.
+            requirements_files = { 'requirements.txt' },
         })
     end,
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://github.com/MeanderingProgrammer/py-requirements.nvim/assets/52591095/6ff
             -- Enabled by default if you do not use `nvim-cmp` set to false
             enable_cmp = true,
             -- Specify what file patterns to apply the plugin to, for use with for example pip-tools.
-            requirements_files = { 'requirements.txt' },
+            file_patterns = { 'requirements.txt' },
         })
     end,
 }

--- a/lua/py-requirements/cmp.lua
+++ b/lua/py-requirements/cmp.lua
@@ -23,9 +23,9 @@ local M = {}
 
 ---@return boolean
 function M:is_available()
-    local requirements_files = require('py-requirements').get_config().requirements_files or {}
+    local file_patterns = require('py-requirements').get_config().file_patterns or {}
 
-    return vim.tbl_contains(requirements_files, vim.fn.expand('%:t'))
+    return vim.tbl_contains(file_patterns, vim.fn.expand('%:t'))
 end
 
 ---@return string

--- a/lua/py-requirements/cmp.lua
+++ b/lua/py-requirements/cmp.lua
@@ -23,7 +23,15 @@ local M = {}
 
 ---@return boolean
 function M:is_available()
-    return vim.fn.expand('%:t') == 'requirements.txt'
+    local requirements_files = require('py-requirements').get_config().requirements_files or {}
+
+    for _, requirements_file in ipairs(requirements_files) do
+        if vim.fn.expand('%:t') == requirements_file then
+            return true
+        end
+    end
+
+    return false
 end
 
 ---@return string

--- a/lua/py-requirements/cmp.lua
+++ b/lua/py-requirements/cmp.lua
@@ -25,13 +25,7 @@ local M = {}
 function M:is_available()
     local requirements_files = require('py-requirements').get_config().requirements_files or {}
 
-    for _, requirements_file in ipairs(requirements_files) do
-        if vim.fn.expand('%:t') == requirements_file then
-            return true
-        end
-    end
-
-    return false
+    return vim.tbl_contains(requirements_files, vim.fn.expand('%:t'))
 end
 
 ---@return string

--- a/lua/py-requirements/init.lua
+++ b/lua/py-requirements/init.lua
@@ -5,6 +5,7 @@ local M = {}
 
 ---@class UserConfig
 ---@field public enable_cmp? boolean
+---@field public requirements_files? string[]
 
 ---@class State
 ---@field config UserConfig
@@ -13,6 +14,7 @@ local M = {}
 local state = {
     config = {
         enable_cmp = true,
+        requirements_files = { 'requirements.txt' },
     },
 }
 
@@ -24,7 +26,7 @@ function M.setup(opts)
     end
 
     local group = vim.api.nvim_create_augroup('PyRequirements', { clear = true })
-    local pattern = 'requirements.txt'
+    local pattern = M.get_config().requirements_files
     vim.api.nvim_create_autocmd('BufRead', {
         group = group,
         pattern = pattern,

--- a/lua/py-requirements/init.lua
+++ b/lua/py-requirements/init.lua
@@ -5,7 +5,7 @@ local M = {}
 
 ---@class UserConfig
 ---@field public enable_cmp? boolean
----@field public requirements_files? string[]
+---@field public file_patterns? string[]
 
 ---@class State
 ---@field config UserConfig
@@ -14,7 +14,7 @@ local M = {}
 local state = {
     config = {
         enable_cmp = true,
-        requirements_files = { 'requirements.txt' },
+        file_patterns = { 'requirements.txt' },
     },
 }
 
@@ -26,7 +26,7 @@ function M.setup(opts)
     end
 
     local group = vim.api.nvim_create_augroup('PyRequirements', { clear = true })
-    local pattern = M.get_config().requirements_files
+    local pattern = M.get_config().file_patterns
     vim.api.nvim_create_autocmd('BufRead', {
         group = group,
         pattern = pattern,

--- a/lua/py-requirements/requirements.lua
+++ b/lua/py-requirements/requirements.lua
@@ -32,6 +32,10 @@ local M = {}
 ---@param line string
 ---@return PythonModule|nil
 function M.parse_module(line_number, line)
+    if string.match(line, '^%s*--hash') then
+        return nil
+    end
+
     --Adding a blank line at the end generally helps parser pull more information
     line = line .. '\n'
     local root = vim.treesitter.get_string_parser(line, 'requirements'):parse()[1]:root()


### PR DESCRIPTION
Allow users to specify multiple file patterns to match against to resolve requirements files. This is useful when using for instance [pip-tools](https://github.com/jazzband/pip-tools) to generate the final requirements.txt from a smaller set of requirements.

Tangentially, this PR also discards any lines in a requirements file that start with `--hash` (many of which are generated for each dependency when using pip-tools), which were otherwise each queried separately. This can probably also be solved by parsing the entire Treesitter tree instead of treating each line as a root, but this was the easiest solution just to make things work, and hopefully shouldn't break any other functionality.

Thanks for the super useful plugin! This has definitely been something I've been missing since switching over from IntelliJ.